### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4.0"
+  - "4.1"
 
 notifications:
   recipients:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Current head build status:
 
-[![Build Status](https://travis-ci.org/raoulmillais/node-7digital-api.png?branch=master)](http://travis-ci.org/raoulmillais/node-7digital-api)
+[![Build Status](https://travis-ci.org/raoulmillais/7digital-api.png?branch=master)](http://travis-ci.org/raoulmillais/node-7digital-api)
 
 ## About 7digital
 


### PR DESCRIPTION
- Fixes the travis badge on the README
- Make travis test all versions of node upto 4.1