### PR TITLE
re-enable agent setting to support keep alive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4.0"
   - "4.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - "0.12"
   - "4.0"
   - "4.1"
+  - "4.2"
+  - "4.3"
+  - "4.4"
 
 notifications:
   recipients:

--- a/lib/request.js
+++ b/lib/request.js
@@ -237,9 +237,6 @@ function dispatch(url, httpMethod, data, headers, hostInfo, credentials,
 	// Make the request
 	apiRequest = http.request({
 		method: httpMethod,
-		// disable connection pooling to get round node's unnecessarily low
-		// 5 max connections
-		agent: false,
 		hostname: hostInfo.host,
 		// Force scheme to http for browserify otherwise it will pick up the
 		// scheme from window.location.protocol which is app:// in firefoxos


### PR DESCRIPTION
The max number of connections/sockets defaults to `Infinity` in versions of Node greater than 0.12. Setting `agent: false` is now potentially degrading performance, as it also disables keep-alive connections (assuming the API servers support and can handle it).

I think there's probably no need to continue supporting 0.10 at this point but might need to assess the impact on the API servers - https://www.nginx.com/blog/http-keepalives-and-web-performance/